### PR TITLE
Fix: Treat empty init expressions in variable declarations as null

### DIFF
--- a/src/main/kotlin/org/abs_models/crowbar/interfaces/ABSInterface.kt
+++ b/src/main/kotlin/org/abs_models/crowbar/interfaces/ABSInterface.kt
@@ -99,8 +99,8 @@ fun translateABSStmtToSymStmt(input: Stmt?) : org.abs_models.crowbar.data.Stmt {
                 }
         }
         is VarDeclStmt -> {
-            val loc = ProgVar(input.varDecl.name, input.varDecl.initExp.type.simpleName)
-            val exp = input.varDecl.initExp
+            val loc = ProgVar(input.varDecl.name, input.varDecl.type.simpleName)
+            val exp = input.varDecl.initExp ?: NullExp()
             return when(exp) {
                 is GetExp       -> SyncStmt(loc, translateABSExpToSymExpr(exp))
                 is NewExp       -> AllocateStmt(loc, translateABSExpToSymExpr(exp))


### PR DESCRIPTION
ABS allows declarations of interface-types without an init expression, but the ABS translation assumes a non-null init expression to be present.

Fix: Interpret a null init expression as a `NullExp`, use the declaration type instead of the init expression type.

The tests all pass. but I'm not entirely sure if it's fine to use `input.varDecl.type.simpleName` instead of `input.varDecl.initExp.type.simpleName`. Would appreciate if someone could double-check this!