### PR TITLE
Refactor special heap replacements

### DIFF
--- a/src/main/kotlin/org/abs_models/crowbar/data/LogicElement.kt
+++ b/src/main/kotlin/org/abs_models/crowbar/data/LogicElement.kt
@@ -156,32 +156,29 @@ fun filterHeapTypes(term : Term, dtype: String) : String{
     val smtdType = ADTRepos.getSMTDType(dtype)
     if (term is Function ) {
         // Remove stores that do not change the sub-heap for type dType
-        if(term.name == "store") {
+        return if(term.name == "store") {
             if (ADTRepos.libPrefix((term.params[1] as Field).dType) == dtype)
-                return "(store " +
+                "(store " +
                         "${filterHeapTypes(term.params[0], dtype)} " +
                         "${term.params[1].toSMT()} " +
                         "${term.params[2].toSMT()})"
             else
-                return filterHeapTypes(term.params[0], dtype)
-        // Rewrite generic anon to correctly typed anon function
-        }
-        else if (term.name == "anon")
-            return "(${smtdType.anon} ${filterHeapTypes(term.params[0], dtype)})"
+                filterHeapTypes(term.params[0], dtype)
+            // Rewrite generic anon to correctly typed anon function
+        } else if (term.name == "anon")
+            "(${smtdType.anon} ${filterHeapTypes(term.params[0], dtype)})"
         else
             throw Exception("${term.prettyPrint()}  is neither an heap nor anon or store function")
 
     }
     // Rewrite generic heap variables to correctly typed sub-heap variables
     else if(term is ProgVar && term.dType == "Heap"){
-        if(term is OldHeap)
-            return smtdType.old
-        else if(term is LastHeap)
-            return smtdType.last
-        else if(term is Heap)
-            return smtdType.heap
-        else
-            return term.name
+        return when (term) {
+            is OldHeap -> smtdType.old
+            is LastHeap -> smtdType.last
+            is Heap -> smtdType.heap
+            else -> term.name
+        }
     }
     else
         throw Exception("${term.prettyPrint()}  is neither an heap nor anon or store function")
@@ -416,7 +413,7 @@ object OldHeap : ProgVar("old", "Heap", HeapType("Heap"))
 object LastHeap : ProgVar("last", "Heap", HeapType("Heap"))
 
 fun store(field: Field, value : Term) : Function = Function("store", listOf(Heap, field, value))
-fun select(field : Field) : Function = Function("select", listOf(Heap, field))
+fun select(field : Field, heap: ProgVar = Heap) : Function = Function("select", listOf(heap, field))
 fun anon(heap : Term) : Function = Function("anon", listOf(heap))
 fun poll(term : Term) : Function = Function("poll", listOf(term))
 fun readFut(term : Expr) : Expr = SExpr("valueOf", listOf(term))
@@ -424,9 +421,12 @@ fun exprToTerm(input : Expr, specialKeyword : String="NONE") : Term {//todo: add
     return when(input){
         is ProgVar -> input
         is Field -> {
-            if(specialKeyword != "NONE")
-                return Function(specialKeyword, listOf(select(input)))
-            return select(input)
+            if(specialKeyword != "NONE" && specialHeapKeywords.containsKey(specialKeyword))
+                select(input, specialHeapKeywords[specialKeyword] as ProgVar)
+            else if(specialKeyword != "NONE")
+                throw Exception("The special heap keyword $specialKeyword is not supported")
+            else
+                select(input)
         }
         is PollExpr -> poll(exprToTerm(input.e1))
         is Const -> Function(input.name)


### PR DESCRIPTION
I had to do some more digging to solve my issue from #22 and noticed that the replacement of the generic heap with the proper special heaps is done in a dedicated function that is not automatically executed when transforming expressions to formulas.

That felt kind of unexpected to me given that `exprToTerm` and `exprToForm` already push down special keywords to fields, so we might as well just insert the right heap there, no? That would also avoid walking over the entire expression tree again when doing the heap replacement.

The current `specialKeyHeapExtract` functions are only called in one place each and all the tests run after my refactoring, so I'm reasonably confident that it didn't break anything.

Still, please check if this violates any assumptions or might break things down the road. Thanks!